### PR TITLE
Dropbox pattern library links

### DIFF
--- a/patterns/index.html
+++ b/patterns/index.html
@@ -50,10 +50,10 @@
 					<section>
 						<h2>Resources</h2>	
 						<ul class="download-list">
-							<li><a href="https://www.dropbox.com/s/deqcj9ez68nn739/Patternlibrary.ai?dl=0">Patterns for Adobe Illustrator</a>
-							<li><a href="https://www.dropbox.com/s/gs44d5141ev8pml/Patternlibrary.psd?dl=0">Patterns for Adobe Photoshop</a>
-							<li><a href="https://www.dropbox.com/s/unrc70riaa7cgvc/Patternlibrary.sketch?dl=0">Patterns for Sketch</a>
-							<li><a href="https://www.dropbox.com/s/7afby9dw8ewmxk4/Patternlibrary-reference.pdf?dl=0">Patterns Visual Reference</a>
+							<li><a href="https://www.dropbox.com/s/deqcj9ez68nn739/Patternlibrary.ai?dl=1">Patterns for Adobe Illustrator</a>
+							<li><a href="https://www.dropbox.com/s/gs44d5141ev8pml/Patternlibrary.psd?dl=1">Patterns for Adobe Photoshop</a>
+							<li><a href="https://www.dropbox.com/s/unrc70riaa7cgvc/Patternlibrary.sketch?dl=1">Patterns for Sketch</a>
+							<li><a href="https://www.dropbox.com/s/7afby9dw8ewmxk4/Patternlibrary-reference.pdf?dl=1">Patterns Visual Reference</a>
 								<small>PDF&thinsp;&mdash;&thinsp;<em>Editing Disabled</em></small></li>
 						</ul>
 					</section>


### PR DESCRIPTION
Replace the static, versioned links to the pattern library files with links to the files in our Dropbox. This ensures the site will always offer the latest version of the files from the repo.

This brings up one question: how should we ensure that an accidental change to the patterns isn't synced with Dropbox? I think the easiest solution is to use OS X's file lock, so they can be opened but must be saved as new files. It won't really impede us from updating them any time we intend to, though. Other suggestions are welcome.
