### PR TITLE
Expand the Typography page with guidelines on font weights and usage.

### DIFF
--- a/typography/index.html
+++ b/typography/index.html
@@ -50,20 +50,20 @@
 						<p>WordPress.com uses two typefaces: <strong>Merriweather</strong> and <strong>Open Sans</strong>. Both are released under Open Source licenses and are served via <a href="https://www.google.com/fonts">Google Fonts</a>.</p>
 
 						<h3>Merriweather</h3>
-						<p>Designed by Eben Sorkin, Merriweather is a graceful, modern serif typeface. We use Merriweather only for user content. This includes posts and post titles, comments, pages; any text that a user creates.</p>
+						<p>Designed by Eben Sorkin, <a href="https://www.google.com/fonts/specimen/Merriweather">Merriweather</a> is a graceful, modern serif typeface. We use Merriweather only for user content. This includes posts and post titles, comments, pages; any text that a user creates. <a href="https://www.google.com/fonts/download?kit=TleLkmP6LSW6TgwbcFuppiEznxM_SBTwoxm6PORu858">Download Merriweather</a> from Google Fonts.</p>
 
 						<h3>Open Sans</h3>
-						<p>Open Sans is a humanist sans serif typeface designed by Steve Matteson. The tone of Open Sans is utilitarian, and as such, we use Open Sans exclusively for text that&rsquo;s part of our UI: headers, form labels, buttons, any text that&rsquo;s not the user&rsquo;s content.</p>
+						<p><a href="https://www.google.com/fonts/specimen/Open+Sans">Open Sans</a> is a humanist sans serif typeface designed by Steve Matteson. The tone of Open Sans is utilitarian, and as such, we use Open Sans exclusively for text that&rsquo;s part of our UI: headers, form labels, buttons, any text that&rsquo;s not the user&rsquo;s content. <a href="https://www.google.com/fonts/download?kit=3hvsV99qyKCBS55e5pvb3ltkqrIMaAZWyLYEoB48lSQ">Download Open Sans</a> from Google Fonts.</p>
 					</section><!-- #typography-typefaces -->
 
 					<section id="typography-weights" class="typography-weights article-section">
 						<h2>Weights and Styles</h2>
 						
-						<p>We use the light (300) and bold (700) weights of Merriweather. Use the light (300) weight anywhere you&rsquo;d usually use normal (400) weight text.</p>
+						<p>We use the light (300) and bold (700) weights of Merriweather. Use the light weight anywhere you&rsquo;d usually use normal weight text.</p>
 						
-						<p>We use the light (300), regular (400), and semibold (600) weights of Open Sans. Anywhere you&rsquo;d ordinarily use a bold (700) weight, use semibold (600) instead.</p>
+						<p>We use the light (300), normal (400), and semibold (600) weights of Open Sans. Anywhere you&rsquo;d ordinarily use a bold weight, use semibold instead.</p>
 						
-						<p>When specifying a font-weight in CSS, always use the numeric value instead of keywords ("400" rather than "normal") to ensure that the correct weights are being used. Always use the browser-default antialiasing; don&rsquo;t disable subpixel antialiasing using the CSS font-smoothing property. </p>
+						<p>When specifying a font-weight in CSS, always use the numeric value instead of keywords ("400" rather than "normal") to ensure that the correct weights are being loaded. Always use the browser-default antialiasing; don&rsquo;t disable subpixel antialiasing using the CSS font-smoothing property. </p>
 					</section><!-- #typography-weights -->
 					
 					<section id="typography-modularscale" class="typography-modularscale article-section">
@@ -128,8 +128,6 @@
 						<h2>Resources</h2>
 
 						<ul class="download-list">
-							<li><a href="http://www.fontsquirrel.com/fonts/open-sans">Open Sans</a> download from FontSquirrel</li>
-							<li><a href="http://www.fontsquirrel.com/fonts/merriweather">Merriweather</a> download from FontSquirrel</li>
 							<li><a href="http://vimeo.com/17079380">More Perfect Typography (Video)</a>, by Tim Brown (Highly recommended)</li>
 							<li><a href="http://alistapart.com/article/more-meaningful-typography">More Meaningful Typography</a>, by Tim Brown for <cite>A List Apart</cite></li>
 							<li><a href="http://blog.8thlight.com/billy-whited/2011/10/28/r-a-ela-tional-design.html">R(a|ela)tional Design</a>, by Billy Whited</li>


### PR DESCRIPTION
This adds an explanation of why and how we use Merriweather and Open Sans for content and interface, respectively, along with more detail about the exact weights we use of each. Updates https://wordpress.com/design-handbook/typography/
