### PR TITLE
Add clarification on weights and antialiasing for typefaces.

### DIFF
--- a/typography/index.html
+++ b/typography/index.html
@@ -59,11 +59,11 @@
 					<section id="typography-weights" class="typography-weights article-section">
 						<h2>Weights and Styles</h2>
 						
-						<p>We use the light (300) and bold (700) weights of Merriweather. Use the light weight anywhere you&rsquo;d usually use normal weight text.</p>
+						<p>On the web, we use the regular (400) and bold (700) weights of Merriweather. In our native apps, use the light (300) weight anywhere you&rsquo;d usually use the regular weight.</p>
 						
 						<p>We use the light (300), normal (400), and semibold (600) weights of Open Sans. Anywhere you&rsquo;d ordinarily use a bold weight, use semibold instead.</p>
 						
-						<p>When specifying a font-weight in CSS, always use the numeric value instead of keywords ("400" rather than "normal") to ensure that the correct weights are being loaded. Always use the browser-default antialiasing; don&rsquo;t disable subpixel antialiasing using the CSS font-smoothing property. </p>
+						<p>When specifying a font-weight in CSS, always use the numeric value instead of keywords ("400" rather than "normal") to ensure that the correct weights are being loaded. For text set in Merriweather, set the CSS font-smoothing property to antialiased/grayscale. For text set in Open Sans, always use the default subpixel antialiasing.</p>
 					</section><!-- #typography-weights -->
 					
 					<section id="typography-modularscale" class="typography-modularscale article-section">


### PR DESCRIPTION
Yesterday we discovered that the 300 weight of Merriweather wouldn't work on the web because of widely-differing rendering on Windows browsers. I've updated the guidance on Typography styling to note that the 400 weight with grayscale antialiasing should be used on the web.
