### PR TITLE
Update our guidance on font weights.

### DIFF
--- a/typography/index.html
+++ b/typography/index.html
@@ -59,11 +59,13 @@
 					<section id="typography-weights" class="typography-weights article-section">
 						<h2>Weights and Styles</h2>
 						
-						<p>On the web, we use the regular (400) and bold (700) weights of Merriweather. In our native apps, use the light (300) weight anywhere you&rsquo;d usually use the regular weight.</p>
+						<p>We use the regular (400) and bold (700) weights of Merriweather. Use the regular weight in most contexts, and the bold weight when added contrast is needed.</p>
 						
-						<p>We use the light (300), normal (400), and semibold (600) weights of Open Sans. Anywhere you&rsquo;d ordinarily use a bold weight, use semibold instead.</p>
+						<p>We use the light (300), normal (400), and semibold (600) weights of Open Sans. Do not use the bold (700) weight. Anywhere you&rsquo;d ordinarily use a bold weight, use semibold instead.</p>
 						
-						<p>When specifying a font-weight in CSS, always use the numeric value instead of keywords ("400" rather than "normal") to ensure that the correct weights are being loaded. For text set in Merriweather, set the CSS font-smoothing property to antialiased/grayscale. For text set in Open Sans, always use the default subpixel antialiasing.</p>
+						<p>When specifying a font-weight in CSS, always use the numeric value instead of keywords ("400" rather than "normal") to ensure that the correct weights are being loaded.</p>
+						
+						<p>For text set in Merriweather, set the CSS font-smoothing property to antialiased/grayscale. For text set in Open Sans, always use the browser&rsquo;s default antialiasing.</p>
 					</section><!-- #typography-weights -->
 					
 					<section id="typography-modularscale" class="typography-modularscale article-section">


### PR DESCRIPTION
- We’re no longer recommending the use of the 300 weight instead of 400 in the apps, see: https://github.com/wordpress-mobile/WordPress-iOS/issues/4121
- Explicitly mention not using the bold weight of Open Sans.
- Separate the weight and font-smoothing guidelines for clarity.

---

NEW TEXT:
### Weights and Styles

We use the regular (400) and bold (700) weights of Merriweather. Use the regular weight in most contexts, and the bold weight when added contrast is needed.

We use the light (300), normal (400), and semibold (600) weights of Open Sans. Do not use the bold (700) weight. Anywhere you’d ordinarily use a bold weight, use semibold instead.

When specifying a font-weight in CSS, always use the numeric value instead of keywords ("400" rather than "normal") to ensure that the correct weights are being loaded.

For text set in Merriweather, set the CSS font-smoothing property to antialiased/grayscale. For text set in Open Sans, always use the browser’s default antialiasing.
