### PR TITLE
Use Merriweather hosted on the WP.com CDN.

### DIFF
--- a/colors/index.html
+++ b/colors/index.html
@@ -11,7 +11,8 @@
 
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
 
-		<link href='https://fonts.googleapis.com/css?family=Merriweather:700|Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 
 	<body>

--- a/iconography/index.html
+++ b/iconography/index.html
@@ -11,7 +11,8 @@
 
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
 
-		<link href='https://fonts.googleapis.com/css?family=Merriweather:700|Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 
 	<body>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
 
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
 
-		<link href='https://fonts.googleapis.com/css?family=Merriweather:700|Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 
 	<body>

--- a/logotype/index.html
+++ b/logotype/index.html
@@ -11,7 +11,8 @@
 
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
 
-		<link href='https://fonts.googleapis.com/css?family=Merriweather:700|Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 
 	<body>

--- a/metrics/index.html
+++ b/metrics/index.html
@@ -11,7 +11,8 @@
 
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
 
-		<link href='https://fonts.googleapis.com/css?family=Merriweather:700|Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 
 	<body>

--- a/patterns/index.html
+++ b/patterns/index.html
@@ -11,7 +11,8 @@
 
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
 
-		<link href='https://fonts.googleapis.com/css?family=Merriweather:700|Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 
 	<body>

--- a/typography/index.html
+++ b/typography/index.html
@@ -11,7 +11,8 @@
 
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
 
-		<link href='https://fonts.googleapis.com/css?family=Merriweather:700|Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
+		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 
 	<body>


### PR DESCRIPTION
We're [switching to a locally-hosted version](https://github.com/Automattic/wp-calypso/pull/2766) of Merriweather in Calypso; this PR updates the Design Handbook to match.
