### PR TITLE
Remove links to the Open Sans stylesheet on Google Fonts.

### DIFF
--- a/colors/index.html
+++ b/colors/index.html
@@ -8,10 +8,7 @@
 		<meta name="viewport" content="width=device-width">
 		<link rel='stylesheet' href='../css/style.css'>
 		<script src='../js/vendor/modernizr-2.6.2.min.js'></script>
-
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
-
-		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
 		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 

--- a/iconography/index.html
+++ b/iconography/index.html
@@ -8,10 +8,7 @@
 		<meta name="viewport" content="width=device-width">
 		<link rel='stylesheet' href='../css/style.css'>
 		<script src='../js/vendor/modernizr-2.6.2.min.js'></script>
-
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
-
-		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
 		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 

--- a/logotype/index.html
+++ b/logotype/index.html
@@ -8,10 +8,7 @@
 		<meta name="viewport" content="width=device-width">
 		<link rel='stylesheet' href='../css/style.css'>
 		<script src='../js/vendor/modernizr-2.6.2.min.js'></script>
-
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
-
-		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
 		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 

--- a/metrics/index.html
+++ b/metrics/index.html
@@ -8,10 +8,7 @@
 		<meta name="viewport" content="width=device-width">
 		<link rel='stylesheet' href='../css/style.css'>
 		<script src='../js/vendor/modernizr-2.6.2.min.js'></script>
-
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
-
-		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
 		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 

--- a/patterns/index.html
+++ b/patterns/index.html
@@ -8,10 +8,7 @@
 		<meta name="viewport" content="width=device-width">
 		<link rel='stylesheet' href='../css/style.css'>
 		<script src='../js/vendor/modernizr-2.6.2.min.js'></script>
-
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
-
-		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
 		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 

--- a/typography/index.html
+++ b/typography/index.html
@@ -8,10 +8,7 @@
 		<meta name="viewport" content="width=device-width">
 		<link rel='stylesheet' href='../css/style.css'>
 		<script src='../js/vendor/modernizr-2.6.2.min.js'></script>
-
 		<link rel="icon" type="image/x-icon" href="https://s2.wp.com/i/favicon.ico" sizes="16x16" />
-
-		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300' rel='stylesheet' type='text/css'>
 		<link href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210' rel='stylesheet' type='text/css'>
 	</head>
 


### PR DESCRIPTION
I was about to update the Design Handbook on wpcom and realized that I hadn’t unlinked the Open Sans stylesheets when I made the change in CSS. This PR removes those links.
