### PR TITLE
Fix the broken link to /metrics/ on the Logotype page.

### DIFF
--- a/logotype/index.html
+++ b/logotype/index.html
@@ -76,7 +76,7 @@
 
 						<hr />
 
-						<p>More on this on the <a href="metrics/">Metrics</a> section of this Handbook.</p>
+						<p>More on this on the <a href="/metrics/">Metrics</a> section of this Handbook.</p>
 
 						<hr />
 					</section>

--- a/logotype/index.html
+++ b/logotype/index.html
@@ -76,7 +76,7 @@
 
 						<hr />
 
-						<p>More on this on the <a href="/metrics/">Metrics</a> section of this Handbook.</p>
+						<p>More on this on the <a href="../metrics/">Metrics</a> section of this Handbook.</p>
 
 						<hr />
 					</section>


### PR DESCRIPTION
The link to Metrics in the Logotype section is broken. This fixes it.