### PR TITLE
replaces SASS with Sass

### DIFF
--- a/colors/index.html
+++ b/colors/index.html
@@ -62,7 +62,7 @@
 											<dd>rgb(&nbsp;0, 135, 190&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$blue-wordpress</dd>
 										</dl>
 										<dl>
@@ -101,7 +101,7 @@
 											<dd>rgb(&nbsp;120, 220, 250&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$blue-light</dd>
 										</dl>										
 										<dl>
@@ -134,7 +134,7 @@
 											<dd>rgb(&nbsp;0, 170, 220&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$blue-medium</dd>
 										</dl>										
 										<dl>
@@ -168,7 +168,7 @@
 											<dd>rgb(&nbsp;0, 80, 130&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$blue-dark</dd>
 										</dl>										
 										<dl>
@@ -209,7 +209,7 @@
 											<dd>rgb(&nbsp;135, 166, 188&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$gray</dd>
 										</dl>										
 										<dl>
@@ -243,7 +243,7 @@
 											<dd>rgb(&nbsp;243, 246, 248&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$gray-light</dd>
 										</dl>										
 										<dl>
@@ -271,7 +271,7 @@
 											<dd>rgb(&nbsp;233, 239, 243&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>lighten(&nbsp;$gray, 30%&nbsp;)</dd>
 										</dl>										
 										<dl>
@@ -299,7 +299,7 @@
 											<dd>rgb(&nbsp;200, 215, 225&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>lighten(&nbsp;$gray, 20%&nbsp;)</dd>
 										</dl>										
 										<dl>
@@ -327,7 +327,7 @@
 											<dd>rgb(&nbsp;168, 190, 206&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>lighten(&nbsp;$gray, 10%&nbsp;)</dd>
 										</dl>										
 										<dl>
@@ -355,7 +355,7 @@
 											<dd>rgb(&nbsp;102, 142, 170&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>darken(&nbsp;$gray, 10%&nbsp;)</dd>
 										</dl>										
 										<dl>
@@ -383,7 +383,7 @@
 											<dd>rgb(&nbsp;79, 116, 142&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>darken(&nbsp;$gray, 20%&nbsp;)</dd>
 										</dl>										
 										<dl>
@@ -411,7 +411,7 @@
 											<dd>rgb(&nbsp;61, 89, 109&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>darken(&nbsp;$gray, 30%&nbsp;)</dd>
 										</dl>										
 										<dl>
@@ -439,7 +439,7 @@
 											<dd>rgb(&nbsp;46, 68, 83&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$gray-dark</dd>
 										</dl>										
 										<dl>
@@ -474,7 +474,7 @@
 											<dd>rgb(&nbsp;213, 78, 33&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$orange-fire</dd>
 										</dl>										
 										<dl>
@@ -507,7 +507,7 @@
 											<dd>rgb(&nbsp;240, 130, 30&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$orange-jazzy</dd>
 										</dl>										
 										<dl>
@@ -547,7 +547,7 @@
 											<dd>rgb(&nbsp;74, 184, 102&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$alert-green</dd>
 										</dl>										
 										<dl>
@@ -575,7 +575,7 @@
 											<dd>rgb(&nbsp;240, 184, 73&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$alert-yellow</dd>
 										</dl>										
 										<dl>
@@ -603,7 +603,7 @@
 											<dd>rgb(&nbsp;217, 79, 79&nbsp;)</dd>
 										</dl>
 										<dl>
-											<dt>SASS</dt>
+											<dt>Sass</dt>
 											<dd>$alert-red</dd>
 										</dl>										
 										<dl>


### PR DESCRIPTION
Sass is not intended to be all caps. It's a bacronym, not and acronym 😄 
