### PR TITLE
Update documentation for new Sass gray lighten and darken variables

### DIFF
--- a/colors/index.html
+++ b/colors/index.html
@@ -272,7 +272,7 @@
 										</dl>
 										<dl>
 											<dt>Sass</dt>
-											<dd>lighten(&nbsp;$gray, 30%&nbsp;)</dd>
+											<dd>$gray-lighten-30</dd>
 										</dl>										
 										<dl>
 											<dt>Android</dt>
@@ -300,7 +300,7 @@
 										</dl>
 										<dl>
 											<dt>Sass</dt>
-											<dd>lighten(&nbsp;$gray, 20%&nbsp;)</dd>
+											<dd>$gray-lighten-20</dd>
 										</dl>										
 										<dl>
 											<dt>Android</dt>
@@ -328,7 +328,7 @@
 										</dl>
 										<dl>
 											<dt>Sass</dt>
-											<dd>lighten(&nbsp;$gray, 10%&nbsp;)</dd>
+											<dd>$gray-lighten-10</dd>
 										</dl>										
 										<dl>
 											<dt>Android</dt>
@@ -356,7 +356,7 @@
 										</dl>
 										<dl>
 											<dt>Sass</dt>
-											<dd>darken(&nbsp;$gray, 10%&nbsp;)</dd>
+											<dd>$gray-darken-10</dd>
 										</dl>										
 										<dl>
 											<dt>Android</dt>
@@ -384,7 +384,7 @@
 										</dl>
 										<dl>
 											<dt>Sass</dt>
-											<dd>darken(&nbsp;$gray, 20%&nbsp;)</dd>
+											<dd>$gray-darken-20</dd>
 										</dl>										
 										<dl>
 											<dt>Android</dt>
@@ -412,7 +412,7 @@
 										</dl>
 										<dl>
 											<dt>Sass</dt>
-											<dd>darken(&nbsp;$gray, 30%&nbsp;)</dd>
+											<dd>$gray-darken-30</dd>
 										</dl>										
 										<dl>
 											<dt>Android</dt>


### PR DESCRIPTION
In automattic/wp-calypso#22181, we introduced new color variables for lighten and darken gray at 10%, 20%, and 30%. This PR documents those new variables.

![image](https://user-images.githubusercontent.com/363749/36868103-e8eee6c4-1d5c-11e8-841f-c8bf128f1837.png)
